### PR TITLE
issuegen: split out udev interface generation 

### DIFF
--- a/usr/lib/systemd/system/console-login-helper-messages-issuegen.service
+++ b/usr/lib/systemd/system/console-login-helper-messages-issuegen.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Generate /run/issue.d/console-login-helper-messages.issue
+Description=Generate console-login-helper-messages issue snippet
 Documentation=https://github.com/coreos/console-login-helper-messages
 Before=systemd-user-sessions.service
 Wants=network-online.target

--- a/usr/lib/udev/rules.d/90-console-login-helper-messages-gensnippet_if.rules
+++ b/usr/lib/udev/rules.d/90-console-login-helper-messages-gensnippet_if.rules
@@ -1,0 +1,2 @@
+ACTION=="add", SUBSYSTEM=="net", ENV{INTERFACE}=="e*", RUN+="/usr/libexec/console-login-helper-messages/gensnippet_udev_if"
+ACTION=="remove", SUBSYSTEM=="net", ENV{INTERFACE}=="e*", RUN+="/usr/libexec/console-login-helper-messages/gensnippet_udev_if"

--- a/usr/lib/udev/rules.d/90-console-login-helper-messages-issuegen.rules
+++ b/usr/lib/udev/rules.d/90-console-login-helper-messages-issuegen.rules
@@ -1,2 +1,0 @@
-ACTION=="add", SUBSYSTEM=="net", ENV{INTERFACE}=="e*", RUN+="/usr/libexec/console-login-helper-messages/issuegen"
-ACTION=="remove", SUBSYSTEM=="net", ENV{INTERFACE}=="e*", RUN+="/usr/libexec/console-login-helper-messages/issuegen"

--- a/usr/libexec/console-login-helper-messages/gensnippet_udev_if
+++ b/usr/libexec/console-login-helper-messages/gensnippet_udev_if
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Generate snippets for network devices, invoked by a udev rule.
+
+# Copyright (c) 2019 Fedora CoreOS Authors. All rights reserved.
+# Copyright (c) 2013 The CoreOS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+# Modified from the CoreOS repository:
+#  * https://github.com/coreos/init/blob/master/scripts/issuegen
+
+set -e
+
+. /usr/libexec/console-login-helper-messages/issuegen.defs
+
+# Add/remove data from udev rules.
+outfile="${RUN_SNIPPETS}/22_${INTERFACE}.issue"
+case "${ACTION}" in
+	add)
+		echo "${INTERFACE}: \\4{${INTERFACE}} \\6{${INTERFACE}}" > ${outfile}
+		;;
+	remove)
+		rm -f ${outfile}
+		;;
+esac

--- a/usr/libexec/console-login-helper-messages/issuegen
+++ b/usr/libexec/console-login-helper-messages/issuegen
@@ -13,16 +13,7 @@
 
 set -e
 
-PKG_NAME=console-login-helper-messages
-ISSUE_SNIPPETS_PATH=${PKG_NAME}/issue.d
-ETC_SNIPPETS="/etc/${ISSUE_SNIPPETS_PATH}"
-RUN_SNIPPETS="/run/${ISSUE_SNIPPETS_PATH}"
-USR_LIB_SNIPPETS="/usr/lib/${ISSUE_SNIPPETS_PATH}"
-
-# Parts of this script write to the `${RUN_SNIPPETS}` directory,
-# make sure it is created upfront.
-mkdir -p "${RUN_SNIPPETS}"
-
+. /usr/libexec/console-login-helper-messages/issuegen.defs
 
 # Provide key fingerprints via issue.
 SSH_DIR=/etc/ssh
@@ -32,18 +23,6 @@ SSH_KEY_OUTDIR="${RUN_SNIPPETS}"
 for KEY_FILE in $(find "${SSH_DIR}" -name 'ssh_host_*_key') ; do
 	ssh-keygen -l -f "${KEY_FILE}"
 done | awk '{print "SSH host key: " $2 " " $4}' > "${SSH_KEY_OUTDIR}/21_ssh_host_keys.issue"
-
-
-# Add/remove data from udev rules.
-UDEV_IF_OUTDIR="${RUN_SNIPPETS}"
-case "${ACTION}" in
-	add)
-		echo "${INTERFACE}: \\4{${INTERFACE}} \\6{${INTERFACE}}" > "${UDEV_IF_OUTDIR}/22_${INTERFACE}.issue"
-		;;
-	remove)
-		rm -f "${UDEV_IF_OUTDIR}/22_${INTERFACE}.issue"
-		;;
-esac
 
 
 # Generate a final issue message from compiling the snippets.

--- a/usr/libexec/console-login-helper-messages/issuegen
+++ b/usr/libexec/console-login-helper-messages/issuegen
@@ -14,42 +14,45 @@
 set -e
 
 PKG_NAME=console-login-helper-messages
-ISSUE_DIR_PUBLIC=issue.d
-ISSUE_DIR_PRIVATE="${PKG_NAME}/issue.d"
+ISSUE_SNIPPETS_PATH=${PKG_NAME}/issue.d
+ETC_SNIPPETS="/etc/${ISSUE_SNIPPETS_PATH}"
+RUN_SNIPPETS="/run/${ISSUE_SNIPPETS_PATH}"
+USR_LIB_SNIPPETS="/usr/lib/${ISSUE_SNIPPETS_PATH}"
+
+# Parts of this script write to the `${RUN_SNIPPETS}` directory,
+# make sure it is created upfront.
+mkdir -p "${RUN_SNIPPETS}"
+
+
+# Provide key fingerprints via issue.
 SSH_DIR=/etc/ssh
-
-# The public directories are to be read by higher-level programs to display
-# the issue on login, e.g. agetty.
-# The private directories are to be read only by this script.
+# Ensure `${SSH_DIR}` is created and can be searched without error.
 mkdir -p "${SSH_DIR}"
-mkdir -p "/run/${ISSUE_DIR_PUBLIC}"
-mkdir -p "/run/${ISSUE_DIR_PRIVATE}"
-
-# Provide key fingerprints via issue
+SSH_KEY_OUTDIR="${RUN_SNIPPETS}"
 for KEY_FILE in $(find "${SSH_DIR}" -name 'ssh_host_*_key') ; do
 	ssh-keygen -l -f "${KEY_FILE}"
-done | awk '{print "SSH host key: " $2 " " $4}' > "/run/${ISSUE_DIR_PRIVATE}/21_ssh_host_keys.issue"
+done | awk '{print "SSH host key: " $2 " " $4}' > "${SSH_KEY_OUTDIR}/21_ssh_host_keys.issue"
 
-# Data from udev rules
+
+# Add/remove data from udev rules.
+UDEV_IF_OUTDIR="${RUN_SNIPPETS}"
 case "${ACTION}" in
 	add)
-		echo "${INTERFACE}: \\4{${INTERFACE}} \\6{${INTERFACE}}" > "/run/${ISSUE_DIR_PRIVATE}/22_${INTERFACE}.issue"
+		echo "${INTERFACE}: \\4{${INTERFACE}} \\6{${INTERFACE}}" > "${UDEV_IF_OUTDIR}/22_${INTERFACE}.issue"
 		;;
 	remove)
-		rm -f "/run/${ISSUE_DIR_PRIVATE}/22_${INTERFACE}.issue"
+		rm -f "${UDEV_IF_OUTDIR}/22_${INTERFACE}.issue"
 		;;
 esac
 
-# TODO: it would be nice to have /run/issue.d be an official directory,
-#       see https://github.com/karelzak/util-linux/commit/1fc82a1360305f696dc1be6105c9c56a9ea03f52#commitcomment-27949895
-#       until then, $GENERATED_ISSUE writes to the privately scoped directory (not in /run/issue.d)
-#
-# Pick 40 as an index as other files can order around it easily.
+
+# Generate a final issue message from compiling the snippets.
+# Pick 40 as a prefix as other files can order around it easily.
 generated_file="/run/${PKG_NAME}/40_${PKG_NAME}.issue"
 generated_string=''
 # Hack around files potentially not existing in the below paths with `|| true`.
-generated_string+=$(cat /etc/${ISSUE_DIR_PRIVATE}/* 2>/dev/null || true)
-generated_string+=$(cat /run/${ISSUE_DIR_PRIVATE}/* 2>/dev/null || true)
-generated_string+=$(cat /usr/lib/${ISSUE_DIR_PRIVATE}/* 2>/dev/null || true)
+generated_string+=$(cat ${ETC_SNIPPETS}/* 2>/dev/null || true)
+generated_string+=$(cat ${RUN_SNIPPETS}/* 2>/dev/null || true)
+generated_string+=$(cat ${USR_LIB_SNIPPETS}/* 2>/dev/null || true)
 
 echo "${generated_string}" > "${generated_file}"

--- a/usr/libexec/console-login-helper-messages/issuegen.defs
+++ b/usr/libexec/console-login-helper-messages/issuegen.defs
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+PKG_NAME=console-login-helper-messages
+ISSUE_SNIPPETS_PATH=${PKG_NAME}/issue.d
+ETC_SNIPPETS="/etc/${ISSUE_SNIPPETS_PATH}"
+RUN_SNIPPETS="/run/${ISSUE_SNIPPETS_PATH}"
+USR_LIB_SNIPPETS="/usr/lib/${ISSUE_SNIPPETS_PATH}"
+
+# Make sure the `${RUN_SNIPPETS}` directory is created upfront,
+# as it may be written to by callers of this script.
+mkdir -p "${RUN_SNIPPETS}"


### PR DESCRIPTION
See commit messages for details.

Takes a commit split from #47 (adding the .path unit).

---

Currently not tested in the last version I pushed, but can be reviewed for feedback on the approach.