### PR TITLE
issuegen,motdgen: remove dependency on network-online.target

### DIFF
--- a/usr/lib/systemd/system/console-login-helper-messages-issuegen.service
+++ b/usr/lib/systemd/system/console-login-helper-messages-issuegen.service
@@ -2,8 +2,7 @@
 Description=Generate /run/issue.d/console-login-helper-messages.issue
 Documentation=https://github.com/coreos/console-login-helper-messages
 Before=systemd-user-sessions.service
-Wants=network-online.target
-After=network-online.target sshd-keygen.target
+After=sshd-keygen.target
 
 [Service]
 Type=oneshot

--- a/usr/lib/systemd/system/console-login-helper-messages-motdgen.service
+++ b/usr/lib/systemd/system/console-login-helper-messages-motdgen.service
@@ -2,8 +2,6 @@
 Description=Generate /run/motd.d/console-login-helper-messages.motd
 Documentation=https://github.com/coreos/console-login-helper-messages
 Before=systemd-user-sessions.service
-Wants=network-online.target
-After=network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This dependency had sneaked into initial work on this
codebase:
https://github.com/coreos/console-login-helper-messages/commit/96aa0d577813bf313182f98a06a2e5c043de8970
Originally Container Linux did not include this dependency:
https://github.com/coreos/init/blob/a1dbdc3a956e82b45ae756c27ad0981afaaef60c/systemd/system/issuegen.service

At the time, it seemed sensible to include as the issuegen
service needed the IP address from the network interface.
However, the generation of the issue snippet containing the
IP address is triggered by the udev rule on appropriate
action from the interface, so there is no need to explicitly
wait on network-online.target. motdgen also does not have
a requirement for the network to be online before starting.

Previously, the dependency on network-online.target meant
starting the issuegen/motdgen services was serialized by
systemd on network-online.target, slowing down login time.
It also gave a misleading message stating issuegen failed,
if the network failed to come up:
https://bugzilla.redhat.com/show_bug.cgi?id=1846169