### PR TITLE
issuegen,motdgen: update unit dependencies to use only .path units

### DIFF
--- a/usr/lib/systemd/system/console-login-helper-messages-issuegen.path
+++ b/usr/lib/systemd/system/console-login-helper-messages-issuegen.path
@@ -1,6 +1,7 @@
 [Unit]
 Description=Monitor console-login-helper-messages runtime issue snippets directory for changes
 Documentation=https://github.com/coreos/console-login-helper-messages
+Before=systemd-user-sessions.service
 
 [Path]
 # Activate issuegen if new snippets are dropped into the runtime

--- a/usr/lib/systemd/system/console-login-helper-messages-issuegen.path
+++ b/usr/lib/systemd/system/console-login-helper-messages-issuegen.path
@@ -3,7 +3,15 @@ Description=Monitor console-login-helper-messages runtime issue snippets directo
 Documentation=https://github.com/coreos/console-login-helper-messages
 
 [Path]
+# Activate issuegen if new snippets are dropped into the runtime
+# directory.
 PathChanged=/run/console-login-helper-messages/issue.d
+# Activate issuegen if snippets were dropped in the runtime directory
+# already before the path started.
+PathExistsGlob=/run/console-login-helper-messages/issue.d/*.issue
+# Activate issuegen if snippets exist in the host config directory.
+PathExistsGlob=/etc/console-login-helper-messages/issue.d/*.issue
+
 Unit=console-login-helper-messages-issuegen.service
 
 [Install]

--- a/usr/lib/systemd/system/console-login-helper-messages-issuegen.service
+++ b/usr/lib/systemd/system/console-login-helper-messages-issuegen.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Generate console-login-helper-messages issue snippet
 Documentation=https://github.com/coreos/console-login-helper-messages
-Before=systemd-user-sessions.service
 After=sshd-keygen.target
 
 [Service]

--- a/usr/lib/systemd/system/console-login-helper-messages-motdgen.path
+++ b/usr/lib/systemd/system/console-login-helper-messages-motdgen.path
@@ -3,7 +3,15 @@ Description=Monitor console-login-helper-messages runtime motd snippets director
 Documentation=https://github.com/coreos/console-login-helper-messages
 
 [Path]
+# Activate motdgen if new snippets are dropped into the runtime
+# directory.
 PathChanged=/run/console-login-helper-messages/motd.d
+# Activate motdgen if snippets were dropped in the runtime directory
+# already before the path started.
+PathExistsGlob=/run/console-login-helper-messages/motd.d/*.motd
+# Activate motdgen if snippets exist in the host config directory.
+PathExistsGlob=/etc/console-login-helper-messages/motd.d/*.motd
+
 Unit=console-login-helper-messages-motdgen.service
 
 [Install]

--- a/usr/lib/systemd/system/console-login-helper-messages-motdgen.path
+++ b/usr/lib/systemd/system/console-login-helper-messages-motdgen.path
@@ -1,6 +1,7 @@
 [Unit]
 Description=Monitor console-login-helper-messages runtime motd snippets directory for changes
 Documentation=https://github.com/coreos/console-login-helper-messages
+Before=systemd-user-sessions.service
 
 [Path]
 # Activate motdgen if new snippets are dropped into the runtime

--- a/usr/lib/systemd/system/console-login-helper-messages-motdgen.service
+++ b/usr/lib/systemd/system/console-login-helper-messages-motdgen.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Generate /run/motd.d/console-login-helper-messages.motd
 Documentation=https://github.com/coreos/console-login-helper-messages
-Before=systemd-user-sessions.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
With this, `-issuegen.path` and `-motdgen.path` become the only trigger to run the `-issuegen.service` and `-motdgen.service`. In my opinion, the purpose of issuegen and motdgen should be only to regenerate a MOTD/issue upon receiving new information (runtime snippets) to include in the final compiled issue/MOTD message - essentially to regenerate only when something new is dropped in `/run/console-login-helper-messages/motd.d` or `/run/console-login-helper-messages/issue.d`.

To include runtime information given by other services outside of this package, a service now need only to write into one of the directories above, and does not need to specify `After=console-login-helper-messages-issuegen.path`. The system presets to integrate console-login-helper-messages into a system are now only to enable `console-login-helper-messages-issuegen.path` and `console-login-helper-messages-motdgen.path` (no need to enable the `.service` files).