### PR TITLE
gensnippet_udev_if: fix copyright date to 2020

### DIFF
--- a/usr/libexec/console-login-helper-messages/gensnippet_udev_if
+++ b/usr/libexec/console-login-helper-messages/gensnippet_udev_if
@@ -2,7 +2,7 @@
 
 # Generate snippets for network devices, invoked by a udev rule.
 
-# Copyright (c) 2019 Fedora CoreOS Authors. All rights reserved.
+# Copyright (c) 2020 Fedora CoreOS Authors. All rights reserved.
 # Copyright (c) 2013 The CoreOS Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.


### PR DESCRIPTION
Minor, but this file was split out in this repo recently this
year. Update its copyright notice to have 2020 instead of 2019.