### PR TITLE
Fix outdated information in reviewers doc, refer to reviewers doc from README

### DIFF
--- a/README-devel.md
+++ b/README-devel.md
@@ -1,7 +1,7 @@
 # console-login-helper-messages - development
 
 The below sections include information on editing the
-cosnole-login-helper-messages source files and testing changes. To get
+console-login-helper-messages source files and testing changes. To get
 started, the suggested workflow is first to
 [build the development container](README.md#building-a-development-container)
 and then to iterate following [Testing changes in a virtual machine](README.md#testing-changes-in-a-virtual-machine).

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Failed Units: 1
 
 See the [manual](manual.md#Installation).
 
+To verify working package functionality manually (for now), see the
+[reviewers](reviewers.md) doc.
+
 ## Customizing
 
 The motd/issue messages are defaults and can be disabled following the [manual](manual.md#Disabling-messages).

--- a/reviewers.md
+++ b/reviewers.md
@@ -1,4 +1,4 @@
-# Manual testing
+# Reviewing and verifying package functionality
 
 Use the following steps to verify the `console-login-helper-messages` package
 works. Install RPMs to test in a machine following [manual](manual.md#installation),
@@ -6,10 +6,7 @@ works. Install RPMs to test in a machine following [manual](manual.md#installati
 
 To see the full instructions available to the user, please see the [manual](manual.md).
 
-## Manual testing
-
-Alternatively to manually installing, the Vagrantfile (see section below)
-may be used to automatically enable the COPR repo and install the packages.
+## Manual tests
 
 - [x] The MOTD was generated
 


### PR DESCRIPTION
reviewers.md: fix title, remove out-of-date text

Fix title to be more general for the document, and remove text
from when previously a Vagrantfile was given in this repo for
testing, which is no longer included.

---

README: refer to reviewers.md file