### PR TITLE
issuegen: reload the agetty console upon generation of new issue snippet

### DIFF
--- a/usr/libexec/console-login-helper-messages/issuegen
+++ b/usr/libexec/console-login-helper-messages/issuegen
@@ -34,3 +34,6 @@ generated_file="/run/${PKG_NAME}/40_${PKG_NAME}.issue"
 source_dirs=("${ETC_SNIPPETS}" "${RUN_SNIPPETS}" "${USR_LIB_SNIPPETS}")
 
 cat_via_tempfile "${generated_file}" ".issue" "${source_dirs[@]}"
+
+# Reload the agetty console upon generation of new issue snippet 
+/usr/sbin/agetty --reload


### PR DESCRIPTION
Fixes #53 
Also, related to https://bugzilla.redhat.com/show_bug.cgi?id=1851103
It will also help to address this comment: https://github.com/coreos/fedora-coreos-tracker/issues/279#issuecomment-632299924