### PR TITLE
[WIP] issuegen, motdgen: Split out runtime/non-runtime services

### DIFF
--- a/usr/lib/console-login-helper-messages/issuegen.defs
+++ b/usr/lib/console-login-helper-messages/issuegen.defs
@@ -8,6 +8,7 @@ issue_snippets_path=${PKG_NAME}/issue.d
 ETC_SNIPPETS="/etc/${issue_snippets_path}"
 RUN_SNIPPETS="/run/${issue_snippets_path}"
 USR_LIB_SNIPPETS="/usr/lib/${issue_snippets_path}"
+STATIC_SNIPPET="/run/${PKG_NAME}/static.issue" # generated at startup
 
 # Make sure the `${RUN_SNIPPETS}` directory is created upfront,
 # as it may be written to by callers of this script.

--- a/usr/lib/console-login-helper-messages/libutil.sh
+++ b/usr/lib/console-login-helper-messages/libutil.sh
@@ -25,16 +25,17 @@ write_via_tempfile() {
     ${mv_Z} "${staged_file}" "${generated_file}"
 }
 
-# Write concatenation of all files with a given suffix from a list of
-# source directories to a target file. The target file is the first
-# argument; suffix the second; and source directories the remaining,
-# searched in the given order in the list. Atomicity of the write to 
-# the target file is given by appending file contents to a tempfile
-# before moving to the target file.
+# Write concatenation of all files with a given suffix from a list of source 
+# directories to a target file and append another file. The target file is the 
+# first argument; suffix the second; file to append the third; and source 
+# directories the remaining, searched in the given order in the list. 
+# Atomicity of the write to the target file is given by appending file contents 
+# to a tempfile before moving to the target file.
 cat_via_tempfile() {
     local generated_file="$1"
     local filter_suffix="$2"
-    shift 2
+    local file_to_append="$3"
+    shift 3
     local source_dirs="$@"
     local staged_file="$(mktemp --tmpdir="${tempfile_dir}" "${tempfile_template}")"
     for source_dir in ${source_dirs[@]}; do
@@ -42,5 +43,6 @@ cat_via_tempfile() {
         # found in the source directory.
         cat "${source_dir}"/*"$filter_suffix" 2>/dev/null >> "${staged_file}" || :
     done
+    cat "${file_to_append}" 2>/dev/null >> "${staged_file}" || :
     ${mv_Z} "${staged_file}" "${generated_file}"
 }

--- a/usr/lib/console-login-helper-messages/motdgen.defs
+++ b/usr/lib/console-login-helper-messages/motdgen.defs
@@ -8,6 +8,7 @@ motd_snippets_path="${PKG_NAME}/motd.d"
 ETC_SNIPPETS="/etc/${motd_snippets_path}"
 RUN_SNIPPETS="/run/${motd_snippets_path}"
 USR_LIB_SNIPPETS="/usr/lib/${motd_snippets_path}"
+STATIC_SNIPPET="/run/${PKG_NAME}/static.motd" # generated at startup
 
 # Parts of this script write to the `${RUN_SNIPPETS}` directory,
 # make sure it is created upfront.

--- a/usr/lib/systemd/system/console-login-helper-messages-issuegen-runtime.service
+++ b/usr/lib/systemd/system/console-login-helper-messages-issuegen-runtime.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Generate console-login-helper-messages issue snippet dynamically
+Documentation=https://github.com/coreos/console-login-helper-messages
+After=console-login-helper-messages-issuegen.service
+
+[Service]
+Type=oneshot
+# This service expects to be started repeatedly after exiting (whenever a new
+# runtime issue snippet is dropped into the directory watched by
+# `console-login-helper-messages-issuegen.path`). `RemainAfterExit` is thus
+# explicitly set to `no`, so that the service can re-execute (otherwise,
+# `start` on this service after it has exited once before does not have any
+# effect).
+RemainAfterExit=no
+ExecStart=/usr/libexec/console-login-helper-messages/issuegen_runtime
+
+[Install]
+WantedBy=multi-user.target

--- a/usr/lib/systemd/system/console-login-helper-messages-issuegen.path
+++ b/usr/lib/systemd/system/console-login-helper-messages-issuegen.path
@@ -10,10 +10,8 @@ PathChanged=/run/console-login-helper-messages/issue.d
 # Activate issuegen if snippets were dropped in the runtime directory
 # already before the path started.
 PathExistsGlob=/run/console-login-helper-messages/issue.d/*.issue
-# Activate issuegen if snippets exist in the host config directory.
-PathExistsGlob=/etc/console-login-helper-messages/issue.d/*.issue
 
-Unit=console-login-helper-messages-issuegen.service
+Unit=console-login-helper-messages-issuegen-runtime.service
 
 [Install]
 WantedBy=multi-user.target

--- a/usr/lib/systemd/system/console-login-helper-messages-issuegen.service
+++ b/usr/lib/systemd/system/console-login-helper-messages-issuegen.service
@@ -5,13 +5,7 @@ Before=systemd-user-sessions.service
 
 [Service]
 Type=oneshot
-# This service expects to be started repeatedly after exiting (whenever a new
-# runtime issue snippet is dropped into the directory watched by
-# `console-login-helper-messages-issuegen.path`). `RemainAfterExit` is thus
-# explicitly set to `no`, so that the service can re-execute (otherwise,
-# `start` on this service after it has exited once before does not have any
-# effect).
-RemainAfterExit=no
+# This service expects to be started only on startup.
 ExecStart=/usr/libexec/console-login-helper-messages/issuegen
 
 [Install]

--- a/usr/lib/systemd/system/console-login-helper-messages-motdgen-runtime.service
+++ b/usr/lib/systemd/system/console-login-helper-messages-motdgen-runtime.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Generate console-login-helper-messages motd snippet
+Documentation=https://github.com/coreos/console-login-helper-messages
+
+[Service]
+Type=oneshot
+# This service expects to be started repeatedly after exiting (whenever a new
+# runtime motd snippet is dropped into the directory watched by
+# `console-login-helper-messages-motdgen.path`). `RemainAfterExit` is thus
+# explicitly set to `no`, so that the service can re-execute (otherwise,
+# `start` on this service after it has exited once before does not have any
+# effect).
+RemainAfterExit=no
+ExecStart=/usr/libexec/console-login-helper-messages/motdgen_runtime
+
+[Install]
+WantedBy=multi-user.target

--- a/usr/lib/systemd/system/console-login-helper-messages-motdgen.path
+++ b/usr/lib/systemd/system/console-login-helper-messages-motdgen.path
@@ -10,10 +10,8 @@ PathChanged=/run/console-login-helper-messages/motd.d
 # Activate motdgen if snippets were dropped in the runtime directory
 # already before the path started.
 PathExistsGlob=/run/console-login-helper-messages/motd.d/*.motd
-# Activate motdgen if snippets exist in the host config directory.
-PathExistsGlob=/etc/console-login-helper-messages/motd.d/*.motd
 
-Unit=console-login-helper-messages-motdgen.service
+Unit=console-login-helper-messages-motdgen-runtime.service
 
 [Install]
 WantedBy=multi-user.target

--- a/usr/lib/systemd/system/console-login-helper-messages-motdgen.service
+++ b/usr/lib/systemd/system/console-login-helper-messages-motdgen.service
@@ -1,16 +1,10 @@
 [Unit]
-Description=Generate console-login-helper-messages motd snippet
+Description=Generate console-login-helper-messages motd snippet dynamically
 Documentation=https://github.com/coreos/console-login-helper-messages
 
 [Service]
 Type=oneshot
-# This service expects to be started repeatedly after exiting (whenever a new
-# runtime motd snippet is dropped into the directory watched by
-# `console-login-helper-messages-motdgen.path`). `RemainAfterExit` is thus
-# explicitly set to `no`, so that the service can re-execute (otherwise,
-# `start` on this service after it has exited once before does not have any
-# effect).
-RemainAfterExit=no
+# This service expects to be started only on startup.
 ExecStart=/usr/libexec/console-login-helper-messages/motdgen
 
 [Install]

--- a/usr/libexec/console-login-helper-messages/issuegen_runtime
+++ b/usr/libexec/console-login-helper-messages/issuegen_runtime
@@ -1,24 +1,24 @@
 #!/usr/bin/bash
 
-# Copyright (c) 2019 Fedora CoreOS Authors. All rights reserved.
+# Copyright (c) 2020 Fedora CoreOS Authors. All rights reserved.
 # Copyright (c) 2013 The CoreOS Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 # Modified from the CoreOS repository: https://github.com/coreos/init/blob/master/scripts/issuegen
 
-# Generate an issue to display before login at startup.
+# Generate an issue to display before login dynamically.
 
 set -e
 
 . /usr/lib/console-login-helper-messages/libutil.sh
 . /usr/lib/console-login-helper-messages/issuegen.defs
 
-# Generate an issue message from compiling the snippets in `/etc` and `/usr/lib`.
-# The generated issue messages will be appended to snippets generated during 
-# runtime.
-source_dirs=("${ETC_SNIPPETS}" "${USR_LIB_SNIPPETS}")
+# Generate a final issue message from compiling the snippets in the runtime directory.
+# Pick 40 as a prefix as other files can order around it easily.
+generated_file="/run/${PKG_NAME}/40_${PKG_NAME}.issue"
+source_dirs=("${RUN_SNIPPETS}")
 
-cat_via_tempfile "${STATIC_SNIPPET}" ".issue" "" "${source_dirs[@]}"
+cat_via_tempfile "${generated_file}" ".issue" "${STATIC_SNIPPET}" "${source_dirs[@]}"
 
 # Reload the agetty console upon generation of new issue snippet 
 /usr/sbin/agetty --reload

--- a/usr/libexec/console-login-helper-messages/motdgen
+++ b/usr/libexec/console-login-helper-messages/motdgen
@@ -6,17 +6,15 @@
 # found in the LICENSE file.
 # Modified from the CoreOS repository: https://github.com/coreos/init/blob/master/scripts/motdgen
 
-# Get updated system information and generate a motd
-# to display this at login.
+# Generate a motd to display before login at startup.
+
+set -e
 
 . /usr/lib/console-login-helper-messages/libutil.sh
 . /usr/lib/console-login-helper-messages/motdgen.defs
 
-set -e
+# Generate a motd from compiling the snippets in `/etc` and `/usr/lib`.
+# The generated motd will be appended to snippets generated during runtime.
+source_dirs=("${ETC_SNIPPETS}" "${USR_LIB_SNIPPETS}")
 
-# Generate a final motd from compiling the snippets.
-# Pick 40 as a prefix as other files can order around it easily.
-generated_file="/run/motd.d/40_${PKG_NAME}.motd"
-source_dirs=("${ETC_SNIPPETS}" "${RUN_SNIPPETS}" "${USR_LIB_SNIPPETS}")
-
-cat_via_tempfile "${generated_file}" ".motd" "${source_dirs[@]}"
+cat_via_tempfile "${STATIC_SNIPPET}" ".motd" "" "${source_dirs[@]}"

--- a/usr/libexec/console-login-helper-messages/motdgen_runtime
+++ b/usr/libexec/console-login-helper-messages/motdgen_runtime
@@ -1,0 +1,21 @@
+#!/usr/bin/bash
+
+# Copyright (c) 2020 Fedora CoreOS Authors. All rights reserved.
+# Copyright (c) 2014 The CoreOS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+# Modified from the CoreOS repository: https://github.com/coreos/init/blob/master/scripts/motdgen
+
+# Generate a motd to display at login dynamically.
+
+set -e
+
+. /usr/lib/console-login-helper-messages/libutil.sh
+. /usr/lib/console-login-helper-messages/motdgen.defs
+
+# Generate a final motd from compiling the snippets in the runtime directory.
+# Pick 40 as a prefix as other files can order around it easily.
+generated_file="/run/motd.d/40_${PKG_NAME}.motd"
+source_dirs=("${RUN_SNIPPETS}")
+
+cat_via_tempfile "${generated_file}" ".motd" "${STATIC_SNIPPET}" "${source_dirs[@]}"


### PR DESCRIPTION
Create `issuegen-runtime.service` and `motdgen-runtime.service` to
have the sole responsibilities of generating new final issue files
or motd files when new snippets are added to the runtime directories.
This was originally the responsibilities of `issuegen.service` and
`motdgen.service`, leading to the undesired behaviour of new
issue/motd files being generated from snippets in non-runtime directories
(e.g. /etc/console-login-helper-messages) when the services are
triggered by files being dropped into the runtime directories.