### PR TITLE
motdgen.service: remove systemd-user-sessions dependency

### DIFF
--- a/usr/lib/systemd/system/console-login-helper-messages-issuegen.service
+++ b/usr/lib/systemd/system/console-login-helper-messages-issuegen.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Generate console-login-helper-messages issue snippet
 Documentation=https://github.com/coreos/console-login-helper-messages
-Before=systemd-user-sessions.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The systemd-user-sessions dependency is no longer needed, since
the .service units should only be triggered by .path units. Such
dependency requirement already exists in motdgen.path.

This dependency is already removed in issuegen.path, so it was 
probably mistakenly kept here (in motdgen.service).