### PR TITLE
Remove `PathExistsGlob` option in `.path` units

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -109,13 +109,15 @@ requested**, e.g. to install all of `issuegen`, `motdgen`, and
 - console-login-helper-messages-profile
 ```
 
-Second, add a systemd preset to enable the issue/motd path units, as
-well as units for specific pieces of information (see
+Second, add a systemd preset to enable the issue/motd path and service 
+units, as well as units for specific pieces of information (see
 [all available units](/usr/lib/systemd/system)). E.g.:
 
 ```
 # /usr/lib/systemd/system-preset/40-console-login-helper-messages.preset
 
+enable console-login-helper-messages-issuegen.service
+enable console-login-helper-messages-motdgen.service
 enable console-login-helper-messages-issuegen.path
 enable console-login-helper-messages-motdgen.path
 enable console-login-helper-messages-gensnippet-os-release.service

--- a/usr/lib/systemd/system/console-login-helper-messages-issuegen.path
+++ b/usr/lib/systemd/system/console-login-helper-messages-issuegen.path
@@ -7,11 +7,6 @@ Before=systemd-user-sessions.service
 # Activate issuegen if new snippets are dropped into the runtime
 # directory.
 PathChanged=/run/console-login-helper-messages/issue.d
-# Activate issuegen if snippets were dropped in the runtime directory
-# already before the path started.
-PathExistsGlob=/run/console-login-helper-messages/issue.d/*.issue
-# Activate issuegen if snippets exist in the host config directory.
-PathExistsGlob=/etc/console-login-helper-messages/issue.d/*.issue
 
 Unit=console-login-helper-messages-issuegen.service
 

--- a/usr/lib/systemd/system/console-login-helper-messages-issuegen.service
+++ b/usr/lib/systemd/system/console-login-helper-messages-issuegen.service
@@ -2,6 +2,10 @@
 Description=Generate console-login-helper-messages issue snippet
 Documentation=https://github.com/coreos/console-login-helper-messages
 Before=systemd-user-sessions.service
+After=console-login-helper-messages-issuegen.path
+# Only run if source directories have `.issue` files.
+ConditionPathExistsGlob=|/run/console-login-helper-messages/issue.d/*.issue
+ConditionPathExistsGlob=|/etc/console-login-helper-messages/issue.d/*.issue
 
 [Service]
 Type=oneshot

--- a/usr/lib/systemd/system/console-login-helper-messages-motdgen.path
+++ b/usr/lib/systemd/system/console-login-helper-messages-motdgen.path
@@ -7,11 +7,6 @@ Before=systemd-user-sessions.service
 # Activate motdgen if new snippets are dropped into the runtime
 # directory.
 PathChanged=/run/console-login-helper-messages/motd.d
-# Activate motdgen if snippets were dropped in the runtime directory
-# already before the path started.
-PathExistsGlob=/run/console-login-helper-messages/motd.d/*.motd
-# Activate motdgen if snippets exist in the host config directory.
-PathExistsGlob=/etc/console-login-helper-messages/motd.d/*.motd
 
 Unit=console-login-helper-messages-motdgen.service
 

--- a/usr/lib/systemd/system/console-login-helper-messages-motdgen.service
+++ b/usr/lib/systemd/system/console-login-helper-messages-motdgen.service
@@ -1,6 +1,10 @@
 [Unit]
 Description=Generate console-login-helper-messages motd snippet
 Documentation=https://github.com/coreos/console-login-helper-messages
+After=console-login-helper-messages-motdgen.path
+# Only run if source directories have `.motd` files.
+ConditionPathExistsGlob=|/run/console-login-helper-messages/motd.d/*.motd
+ConditionPathExistsGlob=|/etc/console-login-helper-messages/motd.d/*.motd
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Addresses https://github.com/coreos/fedora-coreos-tracker/issues/631.

https://github.com/coreos/fedora-coreos-tracker/issues/631#issuecomment-699084342 for more context.