### PR TITLE
profile.sh: Update failed units' output

### DIFF
--- a/usr/share/console-login-helper-messages/profile.sh
+++ b/usr/share/console-login-helper-messages/profile.sh
@@ -4,7 +4,7 @@
 
 # Only print for interactive shells.
 if [[ $- == *i* ]]; then
-	FAILED=$(systemctl list-units --state=failed --no-legend)
+	FAILED=$(systemctl list-units --state=failed --no-legend --plain)
 
 	if [[ ! -z "${FAILED}" ]]; then
 		COUNT=$(wc -l <<<"${FAILED}")


### PR DESCRIPTION
Update to accommodate the new output format of `systemctl list-units`.
Fixes #81 