### PR TITLE
gensnippet_if: Fix infinite recursive function

### DIFF
--- a/usr/libexec/console-login-helper-messages/gensnippet_if
+++ b/usr/libexec/console-login-helper-messages/gensnippet_if
@@ -41,6 +41,11 @@ is_iface_backed_by_real_device() {
     # Check if device has any subordinate devices that are backed by a real 
     # device, recursively.
     for subifacedir in ${iface}/lower_*; do
+        # Bash still runs the loop if the wildcard does not match anything.
+        # Skip non-existent directories.
+        if [ ! -e "$subifacedir" ]; then
+            break
+        fi
         subiface=$(readlink -f ${subifacedir})
         if is_iface_backed_by_real_device ${subiface}; then
             return 0


### PR DESCRIPTION
Due to bash leaving non-matching wildcard patterns unchanged
(instead of expanding it to an empty list), if a device is not real
and does not have a subordinate device, `is_iface_backed_by_real_device()`
will get stuck in an infinite recursive loop, causing segmentation
faults.

Ignore directories that are the result of non-matching wildcard
patterns.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1884236