### PR TITLE
usr/share/profile.sh: Return early if not using systemd

### DIFF
--- a/usr/share/console-login-helper-messages/profile.sh
+++ b/usr/share/console-login-helper-messages/profile.sh
@@ -4,12 +4,17 @@
 
 # Only print for interactive shells.
 if [[ $- == *i* ]]; then
-	FAILED=$(systemctl list-units --state=failed --no-legend --plain)
+    # If not using systemd, return.
+    if ! grep -q 'systemd' /proc/1/stat; then
+        return 0
+    fi
 
-	if [[ ! -z "${FAILED}" ]]; then
-		COUNT=$(wc -l <<<"${FAILED}")
-		echo "[systemd]"
-		echo -e "Failed Units: \033[31m${COUNT}\033[39m"
-		awk '{ print "  " $1 }' <<<"${FAILED}"
-	fi
+    FAILED=$(systemctl list-units --state=failed --no-legend --plain)
+
+    if [[ ! -z "${FAILED}" ]]; then
+        COUNT=$(wc -l <<<"${FAILED}")
+        echo "[systemd]"
+        echo -e "Failed Units: \033[31m${COUNT}\033[39m"
+        awk '{ print "  " $1 }' <<<"${FAILED}"
+    fi
 fi


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1891920
where an error message is printed when systemd is not running.

Also switch to spaces instead of tabs.