### PR TITLE
Add a `sleep 1` after generating, before we exit

### DIFF
--- a/usr/lib/console-login-helper-messages/libutil.sh
+++ b/usr/lib/console-login-helper-messages/libutil.sh
@@ -50,3 +50,11 @@ cat_via_tempfile() {
     done
     ${mv_Z} "${staged_file}" "${generated_file}"
 }
+
+# See https://github.com/coreos/console-login-helper-messages/issues/87
+# We want to avoid service start limits and throttle the rate at
+# which we regenerate.  This ensures the service starts at most once
+# per second.
+ratelimit() {
+    sleep 1
+}

--- a/usr/libexec/console-login-helper-messages/issuegen
+++ b/usr/libexec/console-login-helper-messages/issuegen
@@ -23,3 +23,5 @@ cat_via_tempfile "${generated_file}" ".issue" "${source_dirs[@]}"
 
 # Reload the agetty console upon generation of new issue snippet 
 /usr/sbin/agetty --reload
+
+ratelimit

--- a/usr/libexec/console-login-helper-messages/motdgen
+++ b/usr/libexec/console-login-helper-messages/motdgen
@@ -20,3 +20,5 @@ generated_file="/run/motd.d/40_${PKG_NAME}.motd"
 source_dirs=("${ETC_SNIPPETS}" "${RUN_SNIPPETS}" "${USR_LIB_SNIPPETS}")
 
 cat_via_tempfile "${generated_file}" ".motd" "${source_dirs[@]}"
+
+ratelimit


### PR DESCRIPTION
This imposes throttling and ensures we're not constantly regenerating
when things change quickly (as can happen during system startup).

xref https://github.com/coreos/console-login-helper-messages/issues/87