### PR TITLE
hack: Remove existing CLHM package on VM before rsync

### DIFF
--- a/hack/run_vm.sh
+++ b/hack/run_vm.sh
@@ -9,7 +9,7 @@ mkdir -p $vmdir
 
 image_path="$1"
 
-rm $vmdir/*
+rm -f $vmdir/*
 sshkey_path="$vmdir/id_rsa"
 ssh-keygen -t rsa -f "$sshkey_path" -q -N ""
 ssh_pubkey=$(cat "${sshkey_path}.pub")

--- a/hack/sync_to_vm.sh
+++ b/hack/sync_to_vm.sh
@@ -14,6 +14,10 @@ mkdir -p "./build/rootfs"
 
 podman run --rm --name $pkg -v $top_src_dir:/$pkg $pkg make install DESTDIR=/$pkg/build/rootfs
 
+# Remove console-login-helper-messages from VM if already exists
+ssh $ssh_opts -i $sshkey_path -p $ssh_port root@localhost \
+    dnf remove -y console-login-helper-messages
+
 # Note: don't use the -a (archive) option for rsync - don't preserve
 # file owner (-o) and groups (-g) (these should all be root), otherwise
 # systemd-tmpfiles appears to run into problems creating the runtime


### PR DESCRIPTION
To ensure no bad interactions between the installed CLHM and the
testing CLHM.