### PR TITLE
issuegen.service: Remove `Before=` dependency on `user-sessions.service`

### DIFF
--- a/usr/lib/systemd/system/console-login-helper-messages-issuegen.service
+++ b/usr/lib/systemd/system/console-login-helper-messages-issuegen.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Generate console-login-helper-messages issue snippet
 Documentation=https://github.com/coreos/console-login-helper-messages
-Before=systemd-user-sessions.service
 After=console-login-helper-messages-issuegen.path
 # Only run if source directories have `.issue` files.
 ConditionPathExistsGlob=|/run/console-login-helper-messages/issue.d/*.issue


### PR DESCRIPTION
It should not matter whether `issuegen.service` is run before
`systemd-user-sessions.service` or not. As long as it is run any
time after `issuegen.path`, all issue files in the private `issue.d`
directories should be detected and concatenated. So for consistency
with `motdgen.service`, remove this since it already doesn't exist
there.