### PR TITLE
libutil.sh: Allow generated MOTD files to be read by all users

### DIFF
--- a/usr/lib/console-login-helper-messages/libutil.sh
+++ b/usr/lib/console-login-helper-messages/libutil.sh
@@ -33,6 +33,7 @@ write_via_tempfile() {
     local generated_file="$1"
     local staged_file="$(mktemp --tmpdir="${tempfile_dir}" "${tempfile_template}")"
     cat > "${staged_file}"
+    chmod a+r "${staged_file}"
     ${mv_Z} "${staged_file}" "${generated_file}"
 }
 


### PR DESCRIPTION
Starting from pam 1.4.0-6, pam_motd filters motd by user and group.
Currently, MOTD snippets generated by console-login-helper-messages
are allowed to be read by root only.
Change ownership to be able to be read by all users since we would
like to display this information to everyone.

Closes https://github.com/coreos/console-login-helper-messages/issues/93