### PR TITLE
gensnippet_os_release: fully reset ANSI attributes after ${ANSI_COLOR}

### DIFF
--- a/usr/libexec/console-login-helper-messages/gensnippet_os_release
+++ b/usr/libexec/console-login-helper-messages/gensnippet_os_release
@@ -15,5 +15,5 @@ set -e
 
 source /usr/lib/os-release
 OS_RELEASE_OUTDIR="${RUN_SNIPPETS}"
-echo -e "\e[${ANSI_COLOR}m${PRETTY_NAME}\e[39m" \
+echo -e "\e[${ANSI_COLOR}m${PRETTY_NAME}\e[0m" \
     | write_via_tempfile "${OS_RELEASE_OUTDIR}/21_os_release.motd"


### PR DESCRIPTION
Display attribute 39 resets the terminal to the default foreground color but doesn't reset other attributes such as background color, intensity, or reversed video.  Fedora sets `ANSI_COLOR="0;38;2;60;110;180"`, i.e. a full RGB color tuple.  In gnome-terminal this doesn't implicitly change the intensity and thus renders correctly, but in the Linux console it implicitly enables increased intensity, which is not being reset afterward.  To be safe, reset all display attributes after printing `$PRETTY_NAME`.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/750, which was exposed by https://github.com/coreos/console-login-helper-messages/pull/94.