### PR TITLE
tests: drop issuegen.path status check and some unneeded sleeps

### DIFF
--- a/tests/kola/basic/test-issue.sh
+++ b/tests/kola/basic/test-issue.sh
@@ -32,7 +32,6 @@ fi
 # Check that a new issue snippet is generated when a .issue file is dropped into 
 # the issue run directory.
 echo 'foo' > ${ISSUE_RUN_SNIPPETS_PATH}/10_foo.issue
-sleep 2
 faketty agetty_output.txt agetty --show-issue
 assert_file_has_content agetty_output.txt 'foo'
 ok "display new single issue snippet"
@@ -43,7 +42,6 @@ for i in {1..150};
 do
     echo "Issue snippet: $i" > ${ISSUE_RUN_SNIPPETS_PATH}/${i}_spam.issue
 done
-sleep 2
 faketty agetty_output.txt agetty --show-issue
 for i in {1..150};
 do

--- a/tests/kola/basic/test-issue.sh
+++ b/tests/kola/basic/test-issue.sh
@@ -38,8 +38,7 @@ assert_file_has_content agetty_output.txt 'foo'
 ok "display new single issue snippet"
 
 # Check that a large burst of .issue files dropped into the issue run directory
-# will all get displayed, and that we don't hit any systemd 'start-limit-hit' 
-# failures
+# will all get displayed
 for i in {1..150};
 do
     echo "Issue snippet: $i" > ${ISSUE_RUN_SNIPPETS_PATH}/${i}_spam.issue
@@ -50,8 +49,6 @@ for i in {1..150};
 do
     assert_file_has_content agetty_output.txt "Issue snippet: $i"
 done
-systemctl status ${PKG_NAME}-issuegen.path > issuegen_status.txt
-assert_not_file_has_content issuegen_status.txt "unit-start-limit-hit"
 ok "display burst of new issue snippets"
 
 tap_finish

--- a/tests/kola/basic/test-motd.sh
+++ b/tests/kola/basic/test-motd.sh
@@ -23,7 +23,6 @@ cat my.key.pub >> ~/.ssh/authorized_keys
 # Check that a new motd snippet will be displayed at login from SSH when a .motd
 # file is dropped into the MOTD run directory.
 echo 'foo' > ${MOTD_RUN_SNIPPETS_PATH}/10_foo.motd
-sleep 1
 ( timeout 1 script -c "ssh -tt -o StrictHostKeyChecking=no -i my.key root@localhost" ssh_login_output.txt ) || :
 assert_file_has_content ssh_login_output.txt 'foo'
 ok "display new MOTD"


### PR DESCRIPTION
The `issuegen.path` unit was removed in #91, but we're still checking for it.  This wasn't caught before now because CI was picking up the unit from the old version of clhm shipped in the FCOS base image.

Also, we no longer have to wait for a path unit to fire; agetty should pick up the new snippets immediately.  Drop the corresponding sleeps.

Fixes #95.