### PR TITLE
gensnippet-ssh-keys: Ensure service runs before agetty

### DIFF
--- a/usr/lib/systemd/system/console-login-helper-messages-gensnippet-ssh-keys.service
+++ b/usr/lib/systemd/system/console-login-helper-messages-gensnippet-ssh-keys.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Generate SSH keys snippet for display via console-login-helper-messages
 Documentation=https://github.com/coreos/console-login-helper-messages
+Before=systemd-user-sessions.service
 After=sshd-keygen.target
 
 [Service]

--- a/usr/libexec/console-login-helper-messages/gensnippet_ssh_keys
+++ b/usr/libexec/console-login-helper-messages/gensnippet_ssh_keys
@@ -21,6 +21,3 @@ for KEY_FILE in $(find "${SSH_DIR}" -name 'ssh_host_*_key') ; do
 done \
     | awk '{print "SSH host key: " $2 " " $4}' \
     | write_via_tempfile "${SSH_KEY_OUTDIR}/21_${CLHM_FILE_MARKER}_ssh_host_keys.issue"
-
-# Reload the agetty console upon generation of new issue
-/usr/sbin/agetty --reload


### PR DESCRIPTION
During the major rearchitecting to switch CLHM to use directories
of upstream projects (util-linux), we accidentally dropped a
`Before=` dependency on `systemd-user-sessions.service` when
generating ssh keys snippets. This was previously done in
`issuegen.service`, but that service unit no longer exists, so we
now add the ordering dependency directly in
`gensnippet-ssh-keys.service` to ensure that we drop the files in
the necessary locations before `agetty` starts.

We also don't need the extra `agetty --reload` since we are only
writing files once, and it happens before `agetty` is started.
(This was previously required because `issuegen` supported users
dynamically dropping snippets into CLHM's private directories).