### PR TITLE
ci: constrain test glob more to run our tests

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -3,5 +3,5 @@
 cosaPod {
     checkout scm
     fcosBuild(skipKola: true, make: true)
-    fcosKola(skipUpgrade: true, extraArgs: "ext.*")
+    fcosKola(skipUpgrade: true, extraArgs: "ext.console-login-helper-messages.*")
 }


### PR DESCRIPTION
The `ext.*` glob is too broad. It'll match other tests as well which may
not be defaults.