### PR TITLE
issuegen.service: workaround systemd patch

### DIFF
--- a/usr/lib/systemd/system/console-login-helper-messages-issuegen.service
+++ b/usr/lib/systemd/system/console-login-helper-messages-issuegen.service
@@ -3,9 +3,6 @@ Description=Generate console-login-helper-messages issue snippet
 Documentation=https://github.com/coreos/console-login-helper-messages
 Before=systemd-user-sessions.service
 After=console-login-helper-messages-issuegen.path
-# Only run if source directories have `.issue` files.
-ConditionPathExistsGlob=|/run/console-login-helper-messages/issue.d/*.issue
-ConditionPathExistsGlob=|/etc/console-login-helper-messages/issue.d/*.issue
 # Set rate limit to twice per second just in case. With `ExecStartPre=` below,
 # we should not have any systemd 'start-limit-hit' failures.
 StartLimitIntervalSec=1


### PR DESCRIPTION
An update to systemd now propagates failures up to the triggering unit.
The issuegen service is triggered by the issuegen path unit but is
conditionally run on the existence of .issue files in the issues.d
directory. If no .issue files exist in those directories, then the
issuegen service consider that a failure and propagate that failure up
to the path unit causing the path unit to fail. Ultimately,
console-login-helper-messages will no longer work because the path is
not being monitored.

Removing the condition in the issuegen service will remove the
conditional failure and thus allowing the issuegen path to continue to
monitor the directories. The downside is that the issuegen service will
run whenever any changes are made to the path directories. The
expectation is that these directories are infrequently changed.