### PR TITLE
ShellCheck fixes

### DIFF
--- a/tests/kola/basic/data/libtest.sh
+++ b/tests/kola/basic/data/libtest.sh
@@ -8,7 +8,7 @@ runv() {
 
 N_TESTS=0
 ok() {
-    echo "ok" $@
+    echo "ok" "$@"
     N_TESTS=$((N_TESTS + 1))
 }
 
@@ -18,7 +18,7 @@ tap_finish() {
 }
 
 fatal() {
-    echo error: $@ 1>&2; exit 1
+    echo error: "$@" 1>&2; exit 1
 }
 
 # Dump ls -al + file contents to stderr, then fatal()

--- a/usr/share/console-login-helper-messages/profile.sh
+++ b/usr/share/console-login-helper-messages/profile.sh
@@ -1,5 +1,4 @@
-# /usr/share/console-login-helper-messages/profile.sh
-
+# Print count of failed systemd units for interactive shells
 # Originally from https://github.com/coreos/baselayout/blob/master/baselayout/coreos-profile.sh
 
 # Only print for interactive shells.


### PR DESCRIPTION
ShellCheck was confused by the path at the begining of usr/share/console-login-helper-messages/profile.sh.

Replace it with a comment instead.