### PR TITLE
ci: migrate to new directory and method names

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -2,6 +2,6 @@
 
 cosaPod {
     checkout scm
-    fcosBuild(skipKola: true, make: true)
-    fcosKola(skipUpgrade: true, extraArgs: "ext.console-login-helper-messages.*")
+    cosaBuild(skipKola: true, make: true)
+    kola(skipUpgrade: true, extraArgs: "ext.console-login-helper-messages.*")
 }


### PR DESCRIPTION
The previous `fcos*` ones are deprecated.
See: https://github.com/coreos/coreos-ci-lib/pull/122