### PR TITLE
profile.sh: print failed systemd units to stderr instead

### DIFF
--- a/tests/kola/basic/test-motd.sh
+++ b/tests/kola/basic/test-motd.sh
@@ -24,7 +24,7 @@ cat my.key.pub >> ~/.ssh/authorized_keys
 # Check that a new motd snippet will be displayed at login from SSH when a .motd
 # file is dropped into the MOTD run directory.
 echo 'foo' > "${MOTD_RUN_SNIPPETS_PATH}/10_foo.motd"
-( timeout 1 script -c "ssh -tt -o StrictHostKeyChecking=no -i my.key root@localhost" ssh_login_output.txt ) || :
+( timeout 5 script -c "ssh -tt -o StrictHostKeyChecking=no -i my.key root@localhost" ssh_login_output.txt ) || :
 assert_file_has_content ssh_login_output.txt 'foo'
 ok "display new MOTD"
 

--- a/tests/kola/basic/test-profile.sh
+++ b/tests/kola/basic/test-profile.sh
@@ -25,7 +25,7 @@ systemctl start ${PKG_NAME}-fail-unit-test.service || :
 
 cd $(mktemp -d)
 
-bash -i <<< "echo Displaying failed units" > console-output.txt
+bash -i <<< "echo Displaying failed units" &> console-output.txt
 assert_file_has_content console-output.txt \
     '[systemd]' \
     'Failed Units: ' \

--- a/usr/share/console-login-helper-messages/profile.sh
+++ b/usr/share/console-login-helper-messages/profile.sh
@@ -12,8 +12,11 @@ if [[ $- == *i* ]]; then
 
     if [[ ! -z "${FAILED}" ]]; then
         COUNT=$(wc -l <<<"${FAILED}")
-        echo "[systemd]"
-        echo -e "Failed Units: \033[31m${COUNT}\033[39m"
-        awk '{ print "  " $1 }' <<<"${FAILED}"
+        # output to stderr since it belongs better there but also in case
+        # something automated brokenly starts an interactive ssh session to
+        # capture output...
+        echo "[systemd]" 1>&2
+        echo -e "Failed Units: \033[31m${COUNT}\033[39m" 1>&2
+        awk '{ print "  " $1 }' <<<"${FAILED}" 1>&2
     fi
 fi


### PR DESCRIPTION
This kind of output belongs better on stderr, and also can throw off
things that want to capture output from an SSH command but mistakenly
start the shell as an interactive prompt instead.