### PR TITLE
feat: add warnings for invalid mounts

### DIFF
--- a/hack/sync_to_vm.sh
+++ b/hack/sync_to_vm.sh
@@ -32,6 +32,7 @@ ssh $ssh_opts -i $sshkey_path -p $ssh_port root@localhost <<EOF
 set -xeuo pipefail
 systemctl enable console-login-helper-messages-gensnippet-os-release.service
 systemctl enable console-login-helper-messages-gensnippet-ssh-keys.service
+systemctl enable console-login-helper-messages-gensnippet-check-mounts.service
 systemctl reboot
 EOF
 

--- a/usr/lib/systemd/system/console-login-helper-messages-gensnippet-check-mounts.service
+++ b/usr/lib/systemd/system/console-login-helper-messages-gensnippet-check-mounts.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Warns if mount sources or options for critical system filesystems are incorrect
+Documentation=https://github.com/coreos/console-login-helper-messages
+Before=systemd-user-sessions.service
+
+[Service]
+Type=oneshot
+# Service should only run once at boot - set RemainAfterExit=yes.
+RemainAfterExit=yes
+ExecStart=/usr/libexec/console-login-helper-messages/gensnippet_check_mounts
+
+[Install]
+WantedBy=multi-user.target

--- a/usr/libexec/console-login-helper-messages/gensnippet_check_mounts
+++ b/usr/libexec/console-login-helper-messages/gensnippet_check_mounts
@@ -1,0 +1,39 @@
+#!/usr/bin/bash
+
+# Copyright (c) 2020 Fedora CoreOS Authors. All rights reserved.
+# Copyright (c) 2013 The CoreOS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+# Modified from the CoreOS repository: https://github.com/coreos/init/blob/master/scripts/sshd_keygen
+
+set -e
+
+. /usr/lib/console-login-helper-messages/libutil.sh
+. /usr/lib/console-login-helper-messages/issue.defs
+
+OUTDIR="${RUN_SNIPPETS}"
+
+message=""
+
+# Check if the root filesystem source is "composefs"
+root_source=$(findmnt / --json | jq -r '.filesystems[0].source')
+if [[ "$root_source" != "composefs" ]]; then
+    message+="Warning: Root mountpoint ('/') is not a 'composefs' mount."$'\n'
+fi
+
+# Check if / is mounted read-only
+root_options=$(findmnt / --json | jq -r '.filesystems[].options')
+if [[ $(echo "$root_options" | tr ',' '\n' | grep -c '^ro$') -ne 1 ]]; then
+    message+="Warning: Root mountpoint ('/') is not mounted read-only"$'\n'
+fi
+
+# Check if /sysroot is mounted read-only
+sysroot_options=$(findmnt /sysroot --json | jq -r '.filesystems[].options')
+if [[ $(echo "$sysroot_options" | tr ',' '\n' | grep -c '^ro$') -ne 1 ]]; then
+    message+="Warning: '/sysroot' is not mounted read-only"$'\n'
+fi
+
+# Remove trailing newline
+message="${message%$'\n'}"
+
+echo "$message" | write_via_tempfile "$OUTDIR/21_mount.issue"


### PR DESCRIPTION
Closes #118

Warns if / is not composefs
Warns if / is not read-only
Warns if /sysroot is not read-only